### PR TITLE
Add Scala 3

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -28,6 +28,8 @@ pull_request_rules:
           - check-success~=Test \(ubuntu-latest, 2\.12\.\d+, adopt@1\.11\)
           - check-success~=Test \(ubuntu-latest, 2\.13\.\d+, adopt@1\.8\)
           - check-success~=Test \(ubuntu-latest, 2\.13\.\d+, adopt@1\.11\)
+          - check-success~=Test \(ubuntu-latest, 3\.\d+\.\d+, adopt@1\.8\)
+          - check-success~=Test \(ubuntu-latest, 3\.\d+\.\d+, adopt@1\.11\)
     actions:
       merge:
         method: rebase
@@ -45,6 +47,8 @@ pull_request_rules:
           - check-success~=Test \(ubuntu-latest, 2\.12\.\d+, adopt@1\.11\)
           - check-success~=Test \(ubuntu-latest, 2\.13\.\d+, adopt@1\.8\)
           - check-success~=Test \(ubuntu-latest, 2\.13\.\d+, adopt@1\.11\)
+          - check-success~=Test \(ubuntu-latest, 3\.\d+\.\d+, adopt@1\.8\)
+          - check-success~=Test \(ubuntu-latest, 3\.\d+\.\d+, adopt@1\.11\)
     actions:
       merge:
         method: rebase

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.6, 2.12.14]
+        scala: [2.13.6, 2.12.14, 3.0.1]
         java: [adopt@1.8, adopt@1.11]
     runs-on: ${{ matrix.os }}
     steps:
@@ -116,6 +116,16 @@ jobs:
           name: target-${{ matrix.os }}-2.12.14-${{ matrix.java }}
 
       - name: Inflate target directories (2.12.14)
+        run: |
+          tar xf targets.tar
+          rm targets.tar
+
+      - name: Download target directories (3.0.1)
+        uses: actions/download-artifact@v2
+        with:
+          name: target-${{ matrix.os }}-3.0.1-${{ matrix.java }}
+
+      - name: Inflate target directories (3.0.1)
         run: |
           tar xf targets.tar
           rm targets.tar

--- a/ci-release.sbt
+++ b/ci-release.sbt
@@ -1,5 +1,9 @@
 ThisBuild / scalaVersion := Dependencies.Versions.scala213
-ThisBuild / crossScalaVersions := Seq(Dependencies.Versions.scala213, Dependencies.Versions.scala212)
+ThisBuild / crossScalaVersions := Seq(
+  Dependencies.Versions.scala213,
+  Dependencies.Versions.scala212,
+  Dependencies.Versions.scala3
+)
 ThisBuild / githubWorkflowTargetTags ++= Seq("v*")
 ThisBuild / githubWorkflowJavaVersions := Seq("adopt@1.8", "adopt@1.11")
 

--- a/modules/stackdriver-http-exporter/src/main/scala/io/janstenpickle/trace4cats/stackdriver/StackdriverHttpSpanExporter.scala
+++ b/modules/stackdriver-http-exporter/src/main/scala/io/janstenpickle/trace4cats/stackdriver/StackdriverHttpSpanExporter.scala
@@ -91,7 +91,7 @@ object StackdriverHttpSpanExporter {
           ),
         (uri: Uri) =>
           cachedTokenProvider.accessToken.map { token =>
-            uri.withQueryParam("access_token", token.accessToken)
+            uri.withQueryParam("access_token", token.access_token)
           }
       )
     } yield exporter

--- a/modules/stackdriver-http-exporter/src/main/scala/io/janstenpickle/trace4cats/stackdriver/oauth/AccessToken.scala
+++ b/modules/stackdriver-http-exporter/src/main/scala/io/janstenpickle/trace4cats/stackdriver/oauth/AccessToken.scala
@@ -3,10 +3,10 @@ package io.janstenpickle.trace4cats.stackdriver.oauth
 /** Code adapted from https://github.com/permutive/fs2-google-pubsub
   */
 import io.circe.Codec
-import io.circe.generic.extras.semiauto._
+import io.circe.generic.semiauto._
 
-final case class AccessToken(accessToken: String, tokenType: String, expiresIn: Long)
+final case class AccessToken(access_token: String, token_type: String, expires_in: Long)
 
 object AccessToken {
-  implicit val codec: Codec[AccessToken] = deriveConfiguredCodec
+  implicit val codec: Codec[AccessToken] = deriveCodec
 }

--- a/modules/stackdriver-http-exporter/src/main/scala/io/janstenpickle/trace4cats/stackdriver/oauth/CachedTokenProvider.scala
+++ b/modules/stackdriver-http-exporter/src/main/scala/io/janstenpickle/trace4cats/stackdriver/oauth/CachedTokenProvider.scala
@@ -17,7 +17,7 @@ object CachedTokenProvider {
         private def refreshToken =
           underlying.accessToken.flatTap { token =>
             Clock[F].realTime.flatMap { now =>
-              ref.set(Some((now + token.expiresIn.seconds - expiryOffset, token)))
+              ref.set(Some((now + token.expires_in.seconds - expiryOffset, token)))
             }
           }
 
@@ -28,7 +28,7 @@ object CachedTokenProvider {
               for {
                 now <- Clock[F].realTime
                 t <-
-                  if (now < expiresAt) token.copy(expiresIn = (expiresAt - now).toSeconds).pure[F]
+                  if (now < expiresAt) token.copy(expires_in = (expiresAt - now).toSeconds).pure[F]
                   else refreshToken
               } yield t
           }

--- a/modules/stackdriver-http-exporter/src/main/scala/io/janstenpickle/trace4cats/stackdriver/oauth/GoogleAccountParser.scala
+++ b/modules/stackdriver-http-exporter/src/main/scala/io/janstenpickle/trace4cats/stackdriver/oauth/GoogleAccountParser.scala
@@ -11,20 +11,20 @@ import java.util.regex.Pattern
 
 import cats.syntax.either._
 import io.circe.Codec
-import io.circe.generic.extras.semiauto._
+import io.circe.generic.semiauto._
 
 object GoogleAccountParser {
   case class JsonGoogleServiceAccount(
     `type`: String,
-    projectId: String,
-    privateKeyId: String,
-    privateKey: String,
-    clientEmail: String,
-    authUri: String
+    project_id: String,
+    private_key_id: String,
+    private_key: String,
+    client_email: String,
+    auth_uri: String
   )
 
   object JsonGoogleServiceAccount {
-    implicit final val codec: Codec[JsonGoogleServiceAccount] = deriveConfiguredCodec
+    implicit final val codec: Codec[JsonGoogleServiceAccount] = deriveCodec
   }
 
   final def parse(path: Path): Either[Throwable, GoogleServiceAccount] =
@@ -33,10 +33,10 @@ object GoogleAccountParser {
       json <- io.circe.parser.parse(string)
       serviceAccount <- json.as[JsonGoogleServiceAccount]
       gsa <- Either.catchNonFatal {
-        val spec = new PKCS8EncodedKeySpec(loadPem(serviceAccount.privateKey))
+        val spec = new PKCS8EncodedKeySpec(loadPem(serviceAccount.private_key))
         val kf = KeyFactory.getInstance("RSA")
         GoogleServiceAccount(
-          clientEmail = serviceAccount.clientEmail,
+          clientEmail = serviceAccount.client_email,
           privateKey = kf.generatePrivate(spec).asInstanceOf[RSAPrivateKey]
         )
       }

--- a/modules/stackdriver-http-exporter/src/main/scala/io/janstenpickle/trace4cats/stackdriver/oauth/package.scala
+++ b/modules/stackdriver-http-exporter/src/main/scala/io/janstenpickle/trace4cats/stackdriver/oauth/package.scala
@@ -1,8 +1,0 @@
-package io.janstenpickle.trace4cats.stackdriver
-
-import io.circe.generic.extras.Configuration
-
-package object oauth {
-  implicit val circeConfig: Configuration = Configuration.default.withSnakeCaseMemberNames.withSnakeCaseConstructorNames
-
-}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,9 +4,10 @@ object Dependencies {
   object Versions {
     val scala212 = "2.12.14"
     val scala213 = "2.13.6"
+    val scala3 = "3.0.1"
 
-    val trace4cats = "0.12.0-RC2"
-    val trace4catsExporterHttp = "0.12.0-RC2"
+    val trace4cats = "0.12.0-RC2+17-d73c7ff3"
+    val trace4catsExporterHttp = "0.12.0-RC2+4-5c079741"
 
     val cats = "2.6.1"
     val catsEffect = "3.1.1"
@@ -35,7 +36,7 @@ object Dependencies {
   lazy val trace4catsTestkit = "io.janstenpickle"        %% "trace4cats-testkit"         % Versions.trace4cats
   lazy val trace4catsExporterHttp = "io.janstenpickle"   %% "trace4cats-exporter-http"   % Versions.trace4catsExporterHttp
 
-  lazy val circeGeneric = "io.circe"                   %% "circe-generic-extras"            % Versions.circe
+  lazy val circeGeneric = "io.circe"                   %% "circe-generic"                   % Versions.circe
   lazy val circeParser = "io.circe"                    %% "circe-parser"                    % Versions.circe
   lazy val collectionCompat = "org.scala-lang.modules" %% "scala-collection-compat"         % Versions.collectionCompat
   lazy val googleCredentials = "com.google.auth"        % "google-auth-library-credentials" % Versions.googleCredentials

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
     val scala3 = "3.0.1"
 
     val trace4cats = "0.12.0-RC2+17-d73c7ff3"
-    val trace4catsExporterHttp = "0.12.0-RC2+4-5c079741"
+    val trace4catsExporterHttp = "0.12.0-RC2+4-69bfcea6"
 
     val cats = "2.6.1"
     val catsEffect = "3.1.1"


### PR DESCRIPTION
Replaces `circe-generic-extras` with circe-generic by renaming fields to snake_case. Adds a custom Arbitrary instance to work around a missing `scalacheck-shapeless` dependency on Scala 3.